### PR TITLE
changing some stuff around so it runs a bit faster

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
     layer_manager.sm();
 
     patterns::dynamic::initalize_runtime();
-    thread::spawn(|| {
+    let t1 = thread::spawn(|| {
         let mut p = patterns::dynamic::Pattern::create("examples/fn2.js");
         p.load();
         let now = Instant::now();
@@ -25,7 +25,7 @@ fn main() {
         println!("{}", now.elapsed().as_millis());
     });
 
-    let handle = thread::spawn(|| {
+    let t2 = thread::spawn(|| {
         let mut p = patterns::dynamic::Pattern::create("examples/fn2.js");
         p.load();
         let now = Instant::now();
@@ -35,5 +35,6 @@ fn main() {
         println!("{}", now.elapsed().as_millis());
     });
 
-    handle.join().unwrap();
+    t1.join().unwrap();
+    t2.join().unwrap();
 }

--- a/src/patterns/dynamic.rs
+++ b/src/patterns/dynamic.rs
@@ -1,6 +1,6 @@
 use notify::{watcher, RecursiveMode, Watcher};
 use rusty_v8 as v8;
-use std::borrow::BorrowMut;
+use std::borrow::Borrow;
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::convert::TryFrom;
@@ -66,7 +66,7 @@ impl Pattern {
         let isolate = self.isolate.as_mut().unwrap();
         let scope = &mut v8::HandleScope::with_context(
             isolate, &self.context);
-        let context = v8::Local::new(scope, &self.context);
+        let context: &v8::Context = self.context.borrow();
         //Make a v8 string of the blah
         let code = v8::String::new(scope, &code).unwrap();
         let script = v8::Script::compile(scope, code, None).unwrap();
@@ -86,10 +86,10 @@ impl Pattern {
     pub fn process(&mut self) {
         let scope = &mut v8::HandleScope::with_context(
             self.isolate.as_mut().unwrap(), &self.context);
-        let context = v8::Local::new(scope, &self.context);
+        let context: &v8::Context = self.context.borrow();
         let function_global_handle = self.function.as_ref()
             .expect("function not loaded");
-        let function = v8::Local::new(scope, function_global_handle);
+        let function: &v8::Function = function_global_handle.borrow();
 
         let name = v8::Number::new(scope, 5.0).into();
         let mut try_catch = &mut v8::TryCatch::new(scope);

--- a/src/patterns/dynamic.rs
+++ b/src/patterns/dynamic.rs
@@ -28,6 +28,7 @@ pub struct Pattern {
     handle: String,
     loaded: Once,
     isolate: Option<v8::OwnedIsolate>,
+    function: Option<v8::Global<v8::Function>>,
 }
 
 // static DENO_INIT: Once = Once::new();
@@ -54,6 +55,7 @@ impl Pattern {
             loaded: Once::new(),
             handle: "hello".to_string(),
             isolate: Some(isolate),
+            function: None,
         }
     }
 
@@ -77,48 +79,52 @@ impl Pattern {
     pub fn load(&mut self) {
         let code =
             fs::read_to_string(&self.filename).expect("Something went wrong reading the file");
-        let context = self.global_context();
-        let scope = &mut v8::HandleScope::with_context(self.v8_isolate(), context);
+        let context_global_handle = self.global_context();
+        let isolate = self.isolate.as_mut().unwrap();
+        let scope = &mut v8::HandleScope::with_context(
+            isolate, &context_global_handle);
+        let context = v8::Local::new(scope, &context_global_handle);
         //Make a v8 string of the blah
         let code = v8::String::new(scope, &code).unwrap();
         let script = v8::Script::compile(scope, code, None).unwrap();
         //Execute script to load functions into memory
-        let result = script.run(scope).unwrap();
+        script.run(scope).unwrap();
+        let fn_name = v8::String::new(scope, &self.handle).unwrap();
+        let fn_value = context
+            .global(scope)
+            .get(scope, fn_name.into())
+            .expect("missing function Process");
+        let function = v8::Local::<v8::Function>::try_from(fn_value)
+            .expect("function expected");
+        let function_global_handle = v8::Global::new(scope, function);
+        self.function = Some(function_global_handle);
     }
 
     pub fn process(&mut self) {
-        let mut handle = &self.handle.clone();
-        let context = self.global_context();
-        let scope = &mut v8::HandleScope::with_context(self.v8_isolate(), context);
-        let process_str = v8::String::new(scope, handle).unwrap();
-        let process_fn = scope
-            .get_current_context()
-            .global(scope)
-            .get(scope, process_str.into())
-            .expect("missing function Process");
-        let process_fn =
-            v8::Local::<v8::Function>::try_from(process_fn).expect("function expected");
+        let context_global_handle = self.global_context();
+        let scope = &mut v8::HandleScope::with_context(
+            self.isolate.as_mut().unwrap(), &context_global_handle);
+        let context = v8::Local::new(scope, &context_global_handle);
+        let function_global_handle = self.function.as_ref()
+            .expect("function not loaded");
+        let function = v8::Local::new(scope, function_global_handle);
 
         let name = v8::Number::new(scope, 5.0).into();
-        let result = {
-            let mut try_catch = v8::TryCatch::new(scope);
-            let mut global = try_catch
-                .get_current_context()
-                .global(&mut try_catch)
-                .into();
-            let result = process_fn.call(&mut try_catch, global, &[name]);
-            if result.is_none() {
-                let exception = try_catch.exception().unwrap();
-                let exception_string = exception
-                    .to_string(&mut try_catch)
-                    .unwrap()
-                    .to_rust_string_lossy(&mut try_catch);
+        let mut try_catch = &mut v8::TryCatch::new(scope);
+        let global = context
+            .global(try_catch)
+            .into();
+        let result = function.call(&mut try_catch, global, &[name]);
+        if result.is_none() {
+            let exception = try_catch.exception().unwrap();
+            let exception_string = exception
+                .to_string(&mut try_catch)
+                .unwrap()
+                .to_rust_string_lossy(&mut try_catch);
 
-                panic!("{}", exception_string);
-            }
-            result
-        };
-        let m = result.unwrap().to_number(scope).unwrap();
+            panic!("{}", exception_string);
+        }
+        let m = result.unwrap().to_number(try_catch).unwrap();
         //dbg!(m.value());
     }
 }


### PR DESCRIPTION
runs more than twice as fast now for me, mostly due to not looking up the function by name every time and also by avoiding some copying, using slots, and creating `Local<>`s for the `Global<>`s we have.

i may have missed the reason we're using slots to begin with and there may be a semantic difference from not creating a `Local<>`, so maybe this isn't all good